### PR TITLE
Only recalculateOverhang only on rotate

### DIFF
--- a/octoprint_slicer/static/js/octoprint_slicer.min.js
+++ b/octoprint_slicer/static/js/octoprint_slicer.min.js
@@ -30623,7 +30623,7 @@ function STLViewPort(canvas, width, height) {
     self.recalculateOverhang = function (model) {
         if (!model || !model.orientationOptimizer) return;
         if (model.userData.recalculateOverhangPreviousRotation) {
-            var DEBUGGING = true;
+            var DEBUGGING = false;
             if (model.rotation.equals(model.userData.recalculateOverhangPreviousRotation)) {
                 if (DEBUGGING) {
                     console.log("recalculateOverhang: skipped");

--- a/octoprint_slicer/static/js/octoprint_slicer.min.js
+++ b/octoprint_slicer/static/js/octoprint_slicer.min.js
@@ -30622,10 +30622,23 @@ function STLViewPort(canvas, width, height) {
 
     self.recalculateOverhang = function (model) {
         if (!model || !model.orientationOptimizer) return;
+        if (model.userData.recalculateOverhangPreviousRotation) {
+            var DEBUGGING = true;
+            if (model.rotation.equals(model.userData.recalculateOverhangPreviousRotation)) {
+                if (DEBUGGING) {
+                    console.log("recalculateOverhang: skipped");
+                }
+                return;
+            }
+            if (DEBUGGING) {
+                console.log("recalculateOverhang: can't skip");
+            }
+        }
 
         var orientation = model.orientationOptimizer.printabilityOfOrientationByRotation(model.rotation);
         self.tintSurfaces(model, null, 255, 255, 255); // Clear tints off the whole model
         self.tintSurfaces(model, orientation.overhang, 128, 16, 16);
+        model.userData.recalculateOverhangPreviousRotation = model.rotation.clone();
     };
 
     self.tintSurfaces = function (model, surfaces, r, g, b) {

--- a/src/STLViewPort.js
+++ b/src/STLViewPort.js
@@ -386,7 +386,7 @@ export function STLViewPort( canvas, width, height ) {
     self.recalculateOverhang = function(model) {
         if (!model || !model.orientationOptimizer) return;
         if (model.userData.recalculateOverhangPreviousRotation) {
-            const DEBUGGING = true;
+            const DEBUGGING = false;
             if (model.rotation.equals(model.userData.recalculateOverhangPreviousRotation)) {
                 if (DEBUGGING) {
                     console.log("recalculateOverhang: skipped");

--- a/src/STLViewPort.js
+++ b/src/STLViewPort.js
@@ -385,10 +385,23 @@ export function STLViewPort( canvas, width, height ) {
 
     self.recalculateOverhang = function(model) {
         if (!model || !model.orientationOptimizer) return;
+        if (model.userData.recalculateOverhangPreviousRotation) {
+            const DEBUGGING = true;
+            if (model.rotation.equals(model.userData.recalculateOverhangPreviousRotation)) {
+                if (DEBUGGING) {
+                    console.log("recalculateOverhang: skipped");
+                }
+                return;
+            }
+            if (DEBUGGING) {
+                console.log("recalculateOverhang: can't skip");
+            }
+        }
 
         var orientation = model.orientationOptimizer.printabilityOfOrientationByRotation( model.rotation );
         self.tintSurfaces(model, null, 255, 255, 255); // Clear tints off the whole model
         self.tintSurfaces(model, orientation.overhang, 128, 16, 16);
+        model.userData.recalculateOverhangPreviousRotation = model.rotation.clone();
     };
 
     self.tintSurfaces = function(model, surfaces, r, g, b) {


### PR DESCRIPTION
Improve performance on recalculateOverhang.  Only run when rotation has actually changed.  Otherwise, skip it.