### PR TITLE
Better destination filename

### DIFF
--- a/octoprint_slicer/static/js/octoprint_slicer.min.js
+++ b/octoprint_slicer/static/js/octoprint_slicer.min.js
@@ -12504,6 +12504,1069 @@ STLBinaryExporter.prototype = {
 
 };
 
+/**
+ * @author Mugen87 / https://github.com/Mugen87
+ *
+ * Ported from: https://github.com/maurizzzio/quickhull3d/ by Mauricio Poppe (https://github.com/maurizzzio)
+ *
+ */
+
+var Visible = 0;
+var Deleted = 1;
+
+function QuickHull() {
+
+    this.tolerance = -1;
+
+    this.faces = []; // the generated faces of the convex hull
+    this.newFaces = []; // this array holds the faces that are generated within a single iteration
+
+    // the vertex lists work as follows:
+    //
+    // let 'a' and 'b' be 'Face' instances
+    // let 'v' be points wrapped as instance of 'Vertex'
+    //
+    //     [v, v, ..., v, v, v, ...]
+    //      ^             ^
+    //      |             |
+    //  a.outside     b.outside
+    //
+    this.assigned = new VertexList();
+    this.unassigned = new VertexList();
+
+    this.vertices = []; // vertices of the hull (internal representation of given geometry data)
+}
+
+Object.assign(QuickHull.prototype, {
+
+    setFromPoints: function setFromPoints(points) {
+
+        if (Array.isArray(points) !== true) {
+
+            console.error('THREE.QuickHull: Points parameter is not an array.');
+        }
+
+        if (points.length < 4) {
+
+            console.error('THREE.QuickHull: The algorithm needs at least four points.');
+        }
+
+        this.makeEmpty();
+
+        for (var i = 0, l = points.length; i < l; i++) {
+
+            this.vertices.push(new VertexNode(points[i]));
+        }
+
+        this.compute();
+
+        return this;
+    },
+
+    setFromObject: function setFromObject(object) {
+
+        var points = [];
+
+        object.updateMatrixWorld(true);
+
+        object.traverse(function (node) {
+
+            var i, l, point;
+
+            var geometry = node.geometry;
+
+            if (geometry !== undefined) {
+
+                if (geometry.isGeometry) {
+
+                    var vertices = geometry.vertices;
+
+                    for (i = 0, l = vertices.length; i < l; i++) {
+
+                        point = vertices[i].clone();
+                        point.applyMatrix4(node.matrixWorld);
+
+                        points.push(point);
+                    }
+                } else if (geometry.isBufferGeometry) {
+
+                    var attribute = geometry.attributes.position;
+
+                    if (attribute !== undefined) {
+
+                        for (i = 0, l = attribute.count; i < l; i++) {
+
+                            point = new Vector3();
+
+                            point.fromBufferAttribute(attribute, i).applyMatrix4(node.matrixWorld);
+
+                            points.push(point);
+                        }
+                    }
+                }
+            }
+        });
+
+        return this.setFromPoints(points);
+    },
+
+    makeEmpty: function makeEmpty() {
+
+        this.faces = [];
+        this.vertices = [];
+
+        return this;
+    },
+
+    // Adds a vertex to the 'assigned' list of vertices and assigns it to the given face
+
+    addVertexToFace: function addVertexToFace(vertex, face) {
+
+        vertex.face = face;
+
+        if (face.outside === null) {
+
+            this.assigned.append(vertex);
+        } else {
+
+            this.assigned.insertBefore(face.outside, vertex);
+        }
+
+        face.outside = vertex;
+
+        return this;
+    },
+
+    // Removes a vertex from the 'assigned' list of vertices and from the given face
+
+    removeVertexFromFace: function removeVertexFromFace(vertex, face) {
+
+        if (vertex === face.outside) {
+
+            // fix face.outside link
+
+            if (vertex.next !== null && vertex.next.face === face) {
+
+                // face has at least 2 outside vertices, move the 'outside' reference
+
+                face.outside = vertex.next;
+            } else {
+
+                // vertex was the only outside vertex that face had
+
+                face.outside = null;
+            }
+        }
+
+        this.assigned.remove(vertex);
+
+        return this;
+    },
+
+    // Removes all the visible vertices that a given face is able to see which are stored in the 'assigned' vertext list
+
+    removeAllVerticesFromFace: function removeAllVerticesFromFace(face) {
+
+        if (face.outside !== null) {
+
+            // reference to the first and last vertex of this face
+
+            var start = face.outside;
+            var end = face.outside;
+
+            while (end.next !== null && end.next.face === face) {
+
+                end = end.next;
+            }
+
+            this.assigned.removeSubList(start, end);
+
+            // fix references
+
+            start.prev = end.next = null;
+            face.outside = null;
+
+            return start;
+        }
+    },
+
+    // Removes all the visible vertices that 'face' is able to see
+
+    deleteFaceVertices: function deleteFaceVertices(face, absorbingFace) {
+
+        var faceVertices = this.removeAllVerticesFromFace(face);
+
+        if (faceVertices !== undefined) {
+
+            if (absorbingFace === undefined) {
+
+                // mark the vertices to be reassigned to some other face
+
+                this.unassigned.appendChain(faceVertices);
+            } else {
+
+                // if there's an absorbing face try to assign as many vertices as possible to it
+
+                var vertex = faceVertices;
+
+                do {
+
+                    // we need to buffer the subsequent vertex at this point because the 'vertex.next' reference
+                    // will be changed by upcoming method calls
+
+                    var nextVertex = vertex.next;
+
+                    var distance = absorbingFace.distanceToPoint(vertex.point);
+
+                    // check if 'vertex' is able to see 'absorbingFace'
+
+                    if (distance > this.tolerance) {
+
+                        this.addVertexToFace(vertex, absorbingFace);
+                    } else {
+
+                        this.unassigned.append(vertex);
+                    }
+
+                    // now assign next vertex
+
+                    vertex = nextVertex;
+                } while (vertex !== null);
+            }
+        }
+
+        return this;
+    },
+
+    // Reassigns as many vertices as possible from the unassigned list to the new faces
+
+    resolveUnassignedPoints: function resolveUnassignedPoints(newFaces) {
+
+        if (this.unassigned.isEmpty() === false) {
+
+            var vertex = this.unassigned.first();
+
+            do {
+
+                // buffer 'next' reference, see .deleteFaceVertices()
+
+                var nextVertex = vertex.next;
+
+                var maxDistance = this.tolerance;
+
+                var maxFace = null;
+
+                for (var i = 0; i < newFaces.length; i++) {
+
+                    var face = newFaces[i];
+
+                    if (face.mark === Visible) {
+
+                        var distance = face.distanceToPoint(vertex.point);
+
+                        if (distance > maxDistance) {
+
+                            maxDistance = distance;
+                            maxFace = face;
+                        }
+
+                        if (maxDistance > 1000 * this.tolerance) break;
+                    }
+                }
+
+                // 'maxFace' can be null e.g. if there are identical vertices
+
+                if (maxFace !== null) {
+
+                    this.addVertexToFace(vertex, maxFace);
+                }
+
+                vertex = nextVertex;
+            } while (vertex !== null);
+        }
+
+        return this;
+    },
+
+    // Computes the extremes of a simplex which will be the initial hull
+
+    computeExtremes: function computeExtremes() {
+
+        var min = new Vector3();
+        var max = new Vector3();
+
+        var minVertices = [];
+        var maxVertices = [];
+
+        var i, l, j;
+
+        // initially assume that the first vertex is the min/max
+
+        for (i = 0; i < 3; i++) {
+
+            minVertices[i] = maxVertices[i] = this.vertices[0];
+        }
+
+        min.copy(this.vertices[0].point);
+        max.copy(this.vertices[0].point);
+
+        // compute the min/max vertex on all six directions
+
+        for (i = 0, l = this.vertices.length; i < l; i++) {
+
+            var vertex = this.vertices[i];
+            var point = vertex.point;
+
+            // update the min coordinates
+
+            for (j = 0; j < 3; j++) {
+
+                if (point.getComponent(j) < min.getComponent(j)) {
+
+                    min.setComponent(j, point.getComponent(j));
+                    minVertices[j] = vertex;
+                }
+            }
+
+            // update the max coordinates
+
+            for (j = 0; j < 3; j++) {
+
+                if (point.getComponent(j) > max.getComponent(j)) {
+
+                    max.setComponent(j, point.getComponent(j));
+                    maxVertices[j] = vertex;
+                }
+            }
+        }
+
+        // use min/max vectors to compute an optimal epsilon
+
+        this.tolerance = 3 * Number.EPSILON * (Math.max(Math.abs(min.x), Math.abs(max.x)) + Math.max(Math.abs(min.y), Math.abs(max.y)) + Math.max(Math.abs(min.z), Math.abs(max.z)));
+
+        return { min: minVertices, max: maxVertices };
+    },
+
+    // Computes the initial simplex assigning to its faces all the points
+    // that are candidates to form part of the hull
+
+    computeInitialHull: function () {
+
+        var line3, plane, closestPoint;
+
+        return function computeInitialHull() {
+
+            if (line3 === undefined) {
+
+                line3 = new Line3();
+                plane = new Plane();
+                closestPoint = new Vector3();
+            }
+
+            var vertex,
+                vertices = this.vertices;
+            var extremes = this.computeExtremes();
+            var min = extremes.min;
+            var max = extremes.max;
+
+            var v0, v1, v2, v3;
+            var i, l, j;
+
+            // 1. Find the two vertices 'v0' and 'v1' with the greatest 1d separation
+            // (max.x - min.x)
+            // (max.y - min.y)
+            // (max.z - min.z)
+
+            var distance,
+                maxDistance = 0;
+            var index = 0;
+
+            for (i = 0; i < 3; i++) {
+
+                distance = max[i].point.getComponent(i) - min[i].point.getComponent(i);
+
+                if (distance > maxDistance) {
+
+                    maxDistance = distance;
+                    index = i;
+                }
+            }
+
+            v0 = min[index];
+            v1 = max[index];
+
+            // 2. The next vertex 'v2' is the one farthest to the line formed by 'v0' and 'v1'
+
+            maxDistance = 0;
+            line3.set(v0.point, v1.point);
+
+            for (i = 0, l = this.vertices.length; i < l; i++) {
+
+                vertex = vertices[i];
+
+                if (vertex !== v0 && vertex !== v1) {
+
+                    line3.closestPointToPoint(vertex.point, true, closestPoint);
+
+                    distance = closestPoint.distanceToSquared(vertex.point);
+
+                    if (distance > maxDistance) {
+
+                        maxDistance = distance;
+                        v2 = vertex;
+                    }
+                }
+            }
+
+            // 3. The next vertex 'v3' is the one farthest to the plane 'v0', 'v1', 'v2'
+
+            maxDistance = 0;
+            plane.setFromCoplanarPoints(v0.point, v1.point, v2.point);
+
+            for (i = 0, l = this.vertices.length; i < l; i++) {
+
+                vertex = vertices[i];
+
+                if (vertex !== v0 && vertex !== v1 && vertex !== v2) {
+
+                    distance = Math.abs(plane.distanceToPoint(vertex.point));
+
+                    if (distance > maxDistance) {
+
+                        maxDistance = distance;
+                        v3 = vertex;
+                    }
+                }
+            }
+
+            var faces = [];
+
+            if (plane.distanceToPoint(v3.point) < 0) {
+
+                // the face is not able to see the point so 'plane.normal' is pointing outside the tetrahedron
+
+                faces.push(Face.create(v0, v1, v2), Face.create(v3, v1, v0), Face.create(v3, v2, v1), Face.create(v3, v0, v2));
+
+                // set the twin edge
+
+                for (i = 0; i < 3; i++) {
+
+                    j = (i + 1) % 3;
+
+                    // join face[ i ] i > 0, with the first face
+
+                    faces[i + 1].getEdge(2).setTwin(faces[0].getEdge(j));
+
+                    // join face[ i ] with face[ i + 1 ], 1 <= i <= 3
+
+                    faces[i + 1].getEdge(1).setTwin(faces[j + 1].getEdge(0));
+                }
+            } else {
+
+                // the face is able to see the point so 'plane.normal' is pointing inside the tetrahedron
+
+                faces.push(Face.create(v0, v2, v1), Face.create(v3, v0, v1), Face.create(v3, v1, v2), Face.create(v3, v2, v0));
+
+                // set the twin edge
+
+                for (i = 0; i < 3; i++) {
+
+                    j = (i + 1) % 3;
+
+                    // join face[ i ] i > 0, with the first face
+
+                    faces[i + 1].getEdge(2).setTwin(faces[0].getEdge((3 - i) % 3));
+
+                    // join face[ i ] with face[ i + 1 ]
+
+                    faces[i + 1].getEdge(0).setTwin(faces[j + 1].getEdge(1));
+                }
+            }
+
+            // the initial hull is the tetrahedron
+
+            for (i = 0; i < 4; i++) {
+
+                this.faces.push(faces[i]);
+            }
+
+            // initial assignment of vertices to the faces of the tetrahedron
+
+            for (i = 0, l = vertices.length; i < l; i++) {
+
+                vertex = vertices[i];
+
+                if (vertex !== v0 && vertex !== v1 && vertex !== v2 && vertex !== v3) {
+
+                    maxDistance = this.tolerance;
+                    var maxFace = null;
+
+                    for (j = 0; j < 4; j++) {
+
+                        distance = this.faces[j].distanceToPoint(vertex.point);
+
+                        if (distance > maxDistance) {
+
+                            maxDistance = distance;
+                            maxFace = this.faces[j];
+                        }
+                    }
+
+                    if (maxFace !== null) {
+
+                        this.addVertexToFace(vertex, maxFace);
+                    }
+                }
+            }
+
+            return this;
+        };
+    }(),
+
+    // Removes inactive faces
+
+    reindexFaces: function reindexFaces() {
+
+        var activeFaces = [];
+
+        for (var i = 0; i < this.faces.length; i++) {
+
+            var face = this.faces[i];
+
+            if (face.mark === Visible) {
+
+                activeFaces.push(face);
+            }
+        }
+
+        this.faces = activeFaces;
+
+        return this;
+    },
+
+    // Finds the next vertex to create faces with the current hull
+
+    nextVertexToAdd: function nextVertexToAdd() {
+
+        // if the 'assigned' list of vertices is empty, no vertices are left. return with 'undefined'
+
+        if (this.assigned.isEmpty() === false) {
+
+            var eyeVertex,
+                maxDistance = 0;
+
+            // grap the first available face and start with the first visible vertex of that face
+
+            var eyeFace = this.assigned.first().face;
+            var vertex = eyeFace.outside;
+
+            // now calculate the farthest vertex that face can see
+
+            do {
+
+                var distance = eyeFace.distanceToPoint(vertex.point);
+
+                if (distance > maxDistance) {
+
+                    maxDistance = distance;
+                    eyeVertex = vertex;
+                }
+
+                vertex = vertex.next;
+            } while (vertex !== null && vertex.face === eyeFace);
+
+            return eyeVertex;
+        }
+    },
+
+    // Computes a chain of half edges in CCW order called the 'horizon'.
+    // For an edge to be part of the horizon it must join a face that can see
+    // 'eyePoint' and a face that cannot see 'eyePoint'.
+
+    computeHorizon: function computeHorizon(eyePoint, crossEdge, face, horizon) {
+
+        // moves face's vertices to the 'unassigned' vertex list
+
+        this.deleteFaceVertices(face);
+
+        face.mark = Deleted;
+
+        var edge;
+
+        if (crossEdge === null) {
+
+            edge = crossEdge = face.getEdge(0);
+        } else {
+
+            // start from the next edge since 'crossEdge' was already analyzed
+            // (actually 'crossEdge.twin' was the edge who called this method recursively)
+
+            edge = crossEdge.next;
+        }
+
+        do {
+
+            var twinEdge = edge.twin;
+            var oppositeFace = twinEdge.face;
+
+            if (oppositeFace.mark === Visible) {
+
+                if (oppositeFace.distanceToPoint(eyePoint) > this.tolerance) {
+
+                    // the opposite face can see the vertex, so proceed with next edge
+
+                    this.computeHorizon(eyePoint, twinEdge, oppositeFace, horizon);
+                } else {
+
+                    // the opposite face can't see the vertex, so this edge is part of the horizon
+
+                    horizon.push(edge);
+                }
+            }
+
+            edge = edge.next;
+        } while (edge !== crossEdge);
+
+        return this;
+    },
+
+    // Creates a face with the vertices 'eyeVertex.point', 'horizonEdge.tail' and 'horizonEdge.head' in CCW order
+
+    addAdjoiningFace: function addAdjoiningFace(eyeVertex, horizonEdge) {
+
+        // all the half edges are created in ccw order thus the face is always pointing outside the hull
+
+        var face = Face.create(eyeVertex, horizonEdge.tail(), horizonEdge.head());
+
+        this.faces.push(face);
+
+        // join face.getEdge( - 1 ) with the horizon's opposite edge face.getEdge( - 1 ) = face.getEdge( 2 )
+
+        face.getEdge(-1).setTwin(horizonEdge.twin);
+
+        return face.getEdge(0); // the half edge whose vertex is the eyeVertex
+    },
+
+    //  Adds 'horizon.length' faces to the hull, each face will be linked with the
+    //  horizon opposite face and the face on the left/right
+
+    addNewFaces: function addNewFaces(eyeVertex, horizon) {
+
+        this.newFaces = [];
+
+        var firstSideEdge = null;
+        var previousSideEdge = null;
+
+        for (var i = 0; i < horizon.length; i++) {
+
+            var horizonEdge = horizon[i];
+
+            // returns the right side edge
+
+            var sideEdge = this.addAdjoiningFace(eyeVertex, horizonEdge);
+
+            if (firstSideEdge === null) {
+
+                firstSideEdge = sideEdge;
+            } else {
+
+                // joins face.getEdge( 1 ) with previousFace.getEdge( 0 )
+
+                sideEdge.next.setTwin(previousSideEdge);
+            }
+
+            this.newFaces.push(sideEdge.face);
+            previousSideEdge = sideEdge;
+        }
+
+        // perform final join of new faces
+
+        firstSideEdge.next.setTwin(previousSideEdge);
+
+        return this;
+    },
+
+    // Adds a vertex to the hull
+
+    addVertexToHull: function addVertexToHull(eyeVertex) {
+
+        var horizon = [];
+        var i, face;
+
+        this.unassigned.clear();
+
+        // remove 'eyeVertex' from 'eyeVertex.face' so that it can't be added to the 'unassigned' vertex list
+
+        this.removeVertexFromFace(eyeVertex, eyeVertex.face);
+
+        this.computeHorizon(eyeVertex.point, null, eyeVertex.face, horizon);
+
+        this.addNewFaces(eyeVertex, horizon);
+
+        // reassign 'unassigned' vertices to the new faces
+
+        this.resolveUnassignedPoints(this.newFaces);
+
+        return this;
+    },
+
+    cleanup: function cleanup() {
+
+        this.assigned.clear();
+        this.unassigned.clear();
+        this.newFaces = [];
+
+        return this;
+    },
+
+    compute: function compute() {
+
+        var vertex;
+
+        this.computeInitialHull();
+
+        // add all available vertices gradually to the hull
+
+        while ((vertex = this.nextVertexToAdd()) !== undefined) {
+
+            this.addVertexToHull(vertex);
+        }
+
+        this.reindexFaces();
+
+        this.cleanup();
+
+        return this;
+    }
+
+});
+
+//
+
+function Face() {
+
+    this.normal = new Vector3();
+    this.midpoint = new Vector3();
+    this.area = 0;
+
+    this.constant = 0; // signed distance from face to the origin
+    this.outside = null; // reference to a vertex in a vertex list this face can see
+    this.mark = Visible;
+    this.edge = null;
+}
+
+Object.assign(Face, {
+
+    create: function create(a, b, c) {
+
+        var face = new Face();
+
+        var e0 = new HalfEdge(a, face);
+        var e1 = new HalfEdge(b, face);
+        var e2 = new HalfEdge(c, face);
+
+        // join edges
+
+        e0.next = e2.prev = e1;
+        e1.next = e0.prev = e2;
+        e2.next = e1.prev = e0;
+
+        // main half edge reference
+
+        face.edge = e0;
+
+        return face.compute();
+    }
+
+});
+
+Object.assign(Face.prototype, {
+
+    getEdge: function getEdge(i) {
+
+        var edge = this.edge;
+
+        while (i > 0) {
+
+            edge = edge.next;
+            i--;
+        }
+
+        while (i < 0) {
+
+            edge = edge.prev;
+            i++;
+        }
+
+        return edge;
+    },
+
+    compute: function () {
+
+        var triangle;
+
+        return function compute() {
+
+            if (triangle === undefined) triangle = new Triangle();
+
+            var a = this.edge.tail();
+            var b = this.edge.head();
+            var c = this.edge.next.head();
+
+            triangle.set(a.point, b.point, c.point);
+
+            triangle.normal(this.normal);
+            triangle.midpoint(this.midpoint);
+            this.area = triangle.area();
+
+            this.constant = this.normal.dot(this.midpoint);
+
+            return this;
+        };
+    }(),
+
+    distanceToPoint: function distanceToPoint(point) {
+
+        return this.normal.dot(point) - this.constant;
+    }
+
+});
+
+// Entity for a Doubly-Connected Edge List (DCEL).
+
+function HalfEdge(vertex, face) {
+
+    this.vertex = vertex;
+    this.prev = null;
+    this.next = null;
+    this.twin = null;
+    this.face = face;
+}
+
+Object.assign(HalfEdge.prototype, {
+
+    head: function head() {
+
+        return this.vertex;
+    },
+
+    tail: function tail() {
+
+        return this.prev ? this.prev.vertex : null;
+    },
+
+    length: function length() {
+
+        var head = this.head();
+        var tail = this.tail();
+
+        if (tail !== null) {
+
+            return tail.point.distanceTo(head.point);
+        }
+
+        return -1;
+    },
+
+    lengthSquared: function lengthSquared() {
+
+        var head = this.head();
+        var tail = this.tail();
+
+        if (tail !== null) {
+
+            return tail.point.distanceToSquared(head.point);
+        }
+
+        return -1;
+    },
+
+    setTwin: function setTwin(edge) {
+
+        this.twin = edge;
+        edge.twin = this;
+
+        return this;
+    }
+
+});
+
+// A vertex as a double linked list node.
+
+function VertexNode(point) {
+
+    this.point = point;
+    this.prev = null;
+    this.next = null;
+    this.face = null; // the face that is able to see this vertex
+}
+
+// A double linked list that contains vertex nodes.
+
+function VertexList() {
+
+    this.head = null;
+    this.tail = null;
+}
+
+Object.assign(VertexList.prototype, {
+
+    first: function first() {
+
+        return this.head;
+    },
+
+    last: function last() {
+
+        return this.tail;
+    },
+
+    clear: function clear() {
+
+        this.head = this.tail = null;
+
+        return this;
+    },
+
+    // Inserts a vertex before the target vertex
+
+    insertBefore: function insertBefore(target, vertex) {
+
+        vertex.prev = target.prev;
+        vertex.next = target;
+
+        if (vertex.prev === null) {
+
+            this.head = vertex;
+        } else {
+
+            vertex.prev.next = vertex;
+        }
+
+        target.prev = vertex;
+
+        return this;
+    },
+
+    // Inserts a vertex after the target vertex
+
+    insertAfter: function insertAfter(target, vertex) {
+
+        vertex.prev = target;
+        vertex.next = target.next;
+
+        if (vertex.next === null) {
+
+            this.tail = vertex;
+        } else {
+
+            vertex.next.prev = vertex;
+        }
+
+        target.next = vertex;
+
+        return this;
+    },
+
+    // Appends a vertex to the end of the linked list
+
+    append: function append(vertex) {
+
+        if (this.head === null) {
+
+            this.head = vertex;
+        } else {
+
+            this.tail.next = vertex;
+        }
+
+        vertex.prev = this.tail;
+        vertex.next = null; // the tail has no subsequent vertex
+
+        this.tail = vertex;
+
+        return this;
+    },
+
+    // Appends a chain of vertices where 'vertex' is the head.
+
+    appendChain: function appendChain(vertex) {
+
+        if (this.head === null) {
+
+            this.head = vertex;
+        } else {
+
+            this.tail.next = vertex;
+        }
+
+        vertex.prev = this.tail;
+
+        // ensure that the 'tail' reference points to the last vertex of the chain
+
+        while (vertex.next !== null) {
+
+            vertex = vertex.next;
+        }
+
+        this.tail = vertex;
+
+        return this;
+    },
+
+    // Removes a vertex from the linked list
+
+    remove: function remove(vertex) {
+
+        if (vertex.prev === null) {
+
+            this.head = vertex.next;
+        } else {
+
+            vertex.prev.next = vertex.next;
+        }
+
+        if (vertex.next === null) {
+
+            this.tail = vertex.prev;
+        } else {
+
+            vertex.next.prev = vertex.prev;
+        }
+
+        return this;
+    },
+
+    // Removes a list of vertices whose 'head' is 'a' and whose 'tail' is b
+
+    removeSubList: function removeSubList(a, b) {
+
+        if (a.prev === null) {
+
+            this.head = b.next;
+        } else {
+
+            a.prev.next = b.next;
+        }
+
+        if (b.next === null) {
+
+            this.tail = a.prev;
+        } else {
+
+            b.next.prev = a.prev;
+        }
+
+        return this;
+    },
+
+    isEmpty: function isEmpty() {
+
+        return this.head === null;
+    }
+
+});
+
 /** Detect free variable `global` from Node.js. */
 var freeGlobal = (typeof global === 'undefined' ? 'undefined' : _typeof(global)) == 'object' && global && global.Object === Object && global;
 
@@ -20043,7 +21106,7 @@ var difference = baseRest(function (array, values) {
  * _.last([1, 2, 3]);
  * // => 3
  */
-function last(array) {
+function last$1(array) {
   var length = array == null ? 0 : array.length;
   return length ? array[length - 1] : undefined;
 }
@@ -20075,7 +21138,7 @@ function last(array) {
  * // => [{ 'x': 2 }]
  */
 var differenceBy = baseRest(function (array, values) {
-  var iteratee = last(values);
+  var iteratee = last$1(values);
   if (isArrayLikeObject(iteratee)) {
     iteratee = undefined;
   }
@@ -20106,7 +21169,7 @@ var differenceBy = baseRest(function (array, values) {
  * // => [{ 'x': 2, 'y': 1 }]
  */
 var differenceWith = baseRest(function (array, values) {
-  var comparator = last(values);
+  var comparator = last$1(values);
   if (isArrayLikeObject(comparator)) {
     comparator = undefined;
   }
@@ -21202,7 +22265,7 @@ function findLastKey(object, predicate) {
  * _.head([]);
  * // => undefined
  */
-function head(array) {
+function head$1(array) {
   return array && array.length ? array[0] : undefined;
 }
 
@@ -22300,10 +23363,10 @@ var intersection = baseRest(function (arrays) {
  * // => [{ 'x': 1 }]
  */
 var intersectionBy = baseRest(function (arrays) {
-  var iteratee = last(arrays),
+  var iteratee = last$1(arrays),
       mapped = arrayMap(arrays, castArrayLikeObject);
 
-  if (iteratee === last(mapped)) {
+  if (iteratee === last$1(mapped)) {
     iteratee = undefined;
   } else {
     mapped.pop();
@@ -22333,7 +23396,7 @@ var intersectionBy = baseRest(function (arrays) {
  * // => [{ 'x': 1, 'y': 2 }]
  */
 var intersectionWith = baseRest(function (arrays) {
-  var comparator = last(arrays),
+  var comparator = last$1(arrays),
       mapped = arrayMap(arrays, castArrayLikeObject);
 
   comparator = typeof comparator == 'function' ? comparator : undefined;
@@ -22462,7 +23525,7 @@ function parent(object, path) {
 function baseInvoke(object, path, args) {
   path = castPath(path, object);
   object = parent(object, path);
-  var func = object == null ? object : object[toKey(last(path))];
+  var func = object == null ? object : object[toKey(last$1(path))];
   return func == null ? undefined : apply$1(func, object, args);
 }
 
@@ -24311,7 +25374,7 @@ function nthArg(n) {
 function baseUnset(object, path) {
   path = castPath(path, object);
   object = parent(object, path);
-  return object == null || delete object[toKey(last(path))];
+  return object == null || delete object[toKey(last$1(path))];
 }
 
 /**
@@ -27244,7 +28307,7 @@ function sumBy(array, iteratee) {
  * _.tail([1, 2, 3]);
  * // => [2, 3]
  */
-function tail(array) {
+function tail$1(array) {
   var length = array == null ? 0 : array.length;
   return length ? baseSlice(array, 1, length) : [];
 }
@@ -28496,7 +29559,7 @@ var union$1 = baseRest(function (arrays) {
  * // => [{ 'x': 1 }, { 'x': 2 }]
  */
 var unionBy = baseRest(function (arrays) {
-  var iteratee = last(arrays);
+  var iteratee = last$1(arrays);
   if (isArrayLikeObject(iteratee)) {
     iteratee = undefined;
   }
@@ -28525,7 +29588,7 @@ var unionBy = baseRest(function (arrays) {
  * // => [{ 'x': 1, 'y': 2 }, { 'x': 2, 'y': 1 }, { 'x': 1, 'y': 1 }]
  */
 var unionWith = baseRest(function (arrays) {
-  var comparator = last(arrays);
+  var comparator = last$1(arrays);
   comparator = typeof comparator == 'function' ? comparator : undefined;
   return baseUniq(baseFlatten(arrays, 1, isArrayLikeObject, true), undefined, comparator);
 });
@@ -29095,7 +30158,7 @@ var xor = baseRest(function (arrays) {
  * // => [{ 'x': 2 }]
  */
 var xorBy = baseRest(function (arrays) {
-  var iteratee = last(arrays);
+  var iteratee = last$1(arrays);
   if (isArrayLikeObject(iteratee)) {
     iteratee = undefined;
   }
@@ -29124,7 +30187,7 @@ var xorBy = baseRest(function (arrays) {
  * // => [{ 'x': 2, 'y': 1 }, { 'x': 1, 'y': 1 }]
  */
 var xorWith = baseRest(function (arrays) {
-  var comparator = last(arrays);
+  var comparator = last$1(arrays);
   comparator = typeof comparator == 'function' ? comparator : undefined;
   return baseXor(arrayFilter(arrays, isArrayLikeObject), undefined, comparator);
 });
@@ -29239,13 +30302,13 @@ var zipWith = baseRest(function (arrays) {
 var array = {
   chunk: chunk, compact: compact, concat: concat, difference: difference, differenceBy: differenceBy,
   differenceWith: differenceWith, drop: drop, dropRight: dropRight, dropRightWhile: dropRightWhile, dropWhile: dropWhile,
-  fill: fill$1, findIndex: findIndex$1, findLastIndex: findLastIndex, first: head, flatten: flatten$1,
-  flattenDeep: flattenDeep, flattenDepth: flattenDepth, fromPairs: fromPairs, head: head, indexOf: indexOf$1,
+  fill: fill$1, findIndex: findIndex$1, findLastIndex: findLastIndex, first: head$1, flatten: flatten$1,
+  flattenDeep: flattenDeep, flattenDepth: flattenDepth, fromPairs: fromPairs, head: head$1, indexOf: indexOf$1,
   initial: initial, intersection: intersection, intersectionBy: intersectionBy, intersectionWith: intersectionWith, join: join$1,
-  last: last, lastIndexOf: lastIndexOf$1, nth: nth, pull: pull, pullAll: pullAll,
+  last: last$1, lastIndexOf: lastIndexOf$1, nth: nth, pull: pull, pullAll: pullAll,
   pullAllBy: pullAllBy, pullAllWith: pullAllWith, pullAt: pullAt, remove: remove$1, reverse: reverse$1,
   slice: slice$1, sortedIndex: sortedIndex, sortedIndexBy: sortedIndexBy, sortedIndexOf: sortedIndexOf, sortedLastIndex: sortedLastIndex,
-  sortedLastIndexBy: sortedLastIndexBy, sortedLastIndexOf: sortedLastIndexOf, sortedUniq: sortedUniq, sortedUniqBy: sortedUniqBy, tail: tail,
+  sortedLastIndexBy: sortedLastIndexBy, sortedLastIndexOf: sortedLastIndexOf, sortedUniq: sortedUniq, sortedUniqBy: sortedUniqBy, tail: tail$1,
   take: take, takeRight: takeRight, takeRightWhile: takeRightWhile, takeWhile: takeWhile, union: union$1,
   unionBy: unionBy, unionWith: unionWith, uniq: uniq, uniqBy: uniqBy, uniqWith: uniqWith,
   unzip: unzip, unzipWith: unzipWith, without: without, xor: xor, xorBy: xorBy,
@@ -29772,7 +30835,7 @@ lodash.isWeakMap = lang.isWeakMap;
 lodash.isWeakSet = lang.isWeakSet;
 lodash.join = array.join;
 lodash.kebabCase = string.kebabCase;
-lodash.last = last;
+lodash.last = last$1;
 lodash.lastIndexOf = array.lastIndexOf;
 lodash.lowerCase = string.lowerCase;
 lodash.lowerFirst = string.lowerFirst;
@@ -31366,37 +32429,36 @@ function SlicerViewModel(parameters) {
         $("#slicer-viewport button#split").click(function (event) {
             var originalFilename = self.stlViewPort.selectedModel().userData.filename;
             startLongRunning(self.stlViewPort.splitSelectedModel, function (models) {
-                var partNumber = 1;
-                var _iteratorNormalCompletion = true;
-                var _didIteratorError = false;
-                var _iteratorError = undefined;
+                if (models.length == 1) {
+                    models[0].userData.filename = originalFilename;
+                } else {
+                    var partNumber = 1;
+                    var _iteratorNormalCompletion = true;
+                    var _didIteratorError = false;
+                    var _iteratorError = undefined;
 
-                try {
-                    for (var _iterator = models[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-                        var model = _step.value;
+                    try {
+                        for (var _iterator = models[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                            var model = _step.value;
 
-                        if (models.length < 2) {
-                            model.userData.filename = originalFilename;
-                        } else {
                             model.userData.filename = originalFilename.substr(0, originalFilename.lastIndexOf(".")) + "_split" + partNumber + originalFilename.substr(originalFilename.lastIndexOf("."));
                             partNumber++;
                         }
-                    }
-                } catch (err) {
-                    _didIteratorError = true;
-                    _iteratorError = err;
-                } finally {
-                    try {
-                        if (!_iteratorNormalCompletion && _iterator.return) {
-                            _iterator.return();
-                        }
+                    } catch (err) {
+                        _didIteratorError = true;
+                        _iteratorError = err;
                     } finally {
-                        if (_didIteratorError) {
-                            throw _iteratorError;
+                        try {
+                            if (!_iteratorNormalCompletion && _iterator.return) {
+                                _iterator.return();
+                            }
+                        } finally {
+                            if (_didIteratorError) {
+                                throw _iteratorError;
+                            }
                         }
                     }
                 }
-
                 self.setDestinationFilename();
             });
         });
@@ -31666,29 +32728,27 @@ function SlicerViewModel(parameters) {
 
     // END: Helpers for drawing walls and floor
 
-    var filenames = [];
     self.resetSlicingViewModel = function () {
         self.slicingViewModel.target = undefined;
         self.slicingViewModel.file(undefined);
         self.slicingViewModel.destinationFilename(undefined);
-        filenames = [];
+    };
+
+    self.setSlicingViewModel = function (target, filename) {
+        self.slicingViewModel.target = target;
+        self.slicingViewModel.file(filename);
     };
 
     var previousDestinationFilename = "";
     self.setDestinationFilename = function () {
         if (!self.slicingViewModel.destinationFilename() || self.slicingViewModel.destinationFilename() == previousDestinationFilename) {
             // No previous destination filename or it was unchanged.
-            var _filenames = map$1(self.stlViewPort.models(), function (model) {
+            var filenames = map$1(self.stlViewPort.models(), function (model) {
                 return model.userData.filename;
             });
-            previousDestinationFilename = self.computeDestinationFilename(_filenames);
+            previousDestinationFilename = self.computeDestinationFilename(filenames);
             self.slicingViewModel.destinationFilename(previousDestinationFilename);
         }
-    };
-
-    self.setSlicingViewModel = function (target, filename) {
-        self.slicingViewModel.target = target;
-        self.slicingViewModel.file(filename);
     };
 
     // Returns the destination filename based on which models are loaded.

--- a/octoprint_slicer/static/js/octoprint_slicer.min.js
+++ b/octoprint_slicer/static/js/octoprint_slicer.min.js
@@ -30406,7 +30406,7 @@ function STLViewPort(canvas, width, height) {
 
     self.loadSTL = function (url, onLoad) {
         new STLLoader().load(url, function (geometry) {
-            self.addModelOfGeometry(geometry);
+            onLoad(self.addModelOfGeometry(geometry));
         });
     };
 
@@ -30580,10 +30580,12 @@ function STLViewPort(canvas, width, height) {
     };
 
     self.duplicateSelectedModel = function (copies) {
+        var models = [];
         for (var i = 0; i < copies; i++) {
             var originalModel = self.selectedModel();
-            self.addModelOfGeometry(originalModel.children[0].geometry.clone(), originalModel);
+            models.push(self.addModelOfGeometry(originalModel.children[0].geometry.clone(), originalModel));
         }
+        return models;
     };
 
     self.splitSelectedModel = function () {
@@ -30595,8 +30597,8 @@ function STLViewPort(canvas, width, height) {
         var geometry = originalModel.children[0].geometry;
         var newGeometries = BufferGeometryAnalyzer.isolatedGeometries(geometry);
 
-        forEach$1(newGeometries, function (geometry) {
-            self.addModelOfGeometry(geometry, originalModel);
+        return map$1(newGeometries, function (geometry) {
+            return self.addModelOfGeometry(geometry, originalModel);
         });
 
         self.removeModel(originalModel);
@@ -31202,7 +31204,10 @@ function SlicerViewModel(parameters) {
     self.addSTL = function (target, file) {
         self.newSession = false;
         $('#tab_plugin_slicer > div.translucent-blocker').show();
-        self.stlViewPort.loadSTL(BASEURL + "downloads/files/" + target + "/" + file);
+        self.stlViewPort.loadSTL(BASEURL + "downloads/files/" + target + "/" + file, function (model) {
+            model.userData.filename = file;
+            self.setDestinationFilename();
+        });
     };
 
     self.onModelAdd = function (event) {
@@ -31224,6 +31229,7 @@ function SlicerViewModel(parameters) {
         if (self.stlViewPort.models().length == 0) {
             self.resetToDefault();
         }
+        self.setDestinationFilename();
         updateValueInputs();
         updateControlState();
         new ModelArranger().arrange(self.stlViewPort.models());
@@ -31356,14 +31362,29 @@ function SlicerViewModel(parameters) {
         });
 
         $("#slicer-viewport button#split").click(function (event) {
-            startLongRunning(self.stlViewPort.splitSelectedModel);
+            var originalFilename = self.stlViewPort.selectedModel().userData.filename;
+            var models = startLongRunning(self.stlViewPort.splitSelectedModel);
+            var partNumber = 1;
+            forEach$1(models, function (model) {
+                if (models.length < 2) {
+                    model.userData.filename = originalFilename;
+                } else {
+                    model.userData.filename = originalFilename.substr(0, originalFilename.lastIndexOf(".")) + "_split" + partNumber + originalFilename.substr(originalFilename.lastIndexOf(".") + 1);
+                }
+            });
+            self.setDestinationFilename();
         });
 
         $("#slicer-viewport button#duplicate").click(function (event) {
             var copies = parseInt(prompt("The number of copies you want to duplicate:", 1));
             if (copies != NaN) {
-                startLongRunning(self.stlViewPort.duplicateSelectedModel.bind(self, copies));
+                var originalFilename = self.stlViewPoint.selectedModel().userData.filename;
+                var models = startLongRunning(self.stlViewPort.duplicateSelectedModel.bind(self, copies));
+                forEach$1(models, function (model) {
+                    model.userData.filename = originalFilename;
+                });
             }
+            self.setDestinationFilename();
         });
 
         $("#slicer-viewport button#lay-flat").click(function (event) {
@@ -31618,31 +31639,97 @@ function SlicerViewModel(parameters) {
 
     // END: Helpers for drawing walls and floor
 
+    var filenames = [];
     self.resetSlicingViewModel = function () {
         self.slicingViewModel.target = undefined;
         self.slicingViewModel.file(undefined);
         self.slicingViewModel.destinationFilename(undefined);
+        filenames = [];
+    };
+
+    var previousDestinationFilename = "";
+    self.setDestinationFilename = function () {
+        if (!self.slicingViewModel.destinationFilename() || self.slicingViewModel.destinationFilename() == previousDestinationFilename) {
+            // No previous destination filename or it was unchanged.
+            var _filenames = map$1(self.stlViewPort.models(), function (model) {
+                return model.userData.filename;
+            });
+            previousDestinationFilename = self.computeDestinationFilename(_filenames);
+            self.slicingViewModel.destinationFilename(previousDestinationFilename);
+        }
     };
 
     self.setSlicingViewModel = function (target, filename) {
-        if (!self.slicingViewModel.destinationFilename()) {
-            // A model is added to an empty bed
-            self.slicingViewModel.target = target;
-            self.slicingViewModel.file(filename);
-            self.slicingViewModel.destinationFilename(self.computeDestinationFilename(filename));
-        }
+        self.slicingViewModel.target = target;
+        self.slicingViewModel.file(filename);
     };
 
     // Returns the destination filename based on which models are loaded.
     // The destination filename is without the final .gco on it because
     // that will depend on the slicer.
-    self.computeDestinationFilename = function (inputFilename) {
-        // TODO: For now, just use the first model's name.
-        var destinationFilename = inputFilename.substr(0, inputFilename.lastIndexOf("."));
-        if (destinationFilename.lastIndexOf("/") != 0) {
-            destinationFilename = destinationFilename.substr(destinationFilename.lastIndexOf("/") + 1);
+    self.computeDestinationFilename = function (inputFilenames) {
+        if (inputFilenames.length == 0) {
+            return "";
         }
-        return destinationFilename;
+        // First, sanitize the filenames to extract the file name.
+        var destFilenames = map$1(inputFilenames, function (inputFilename) {
+            var destFilename = inputFilename.substr(0, inputFilename.lastIndexOf("."));
+            if (destFilename.lastIndexOf("/") != 0) {
+                destFilename = destFilename.substr(destFilename.lastIndexOf("/") + 1);
+            }
+            return destFilename;
+        });
+
+        // Find the common prefix.
+        var first$$1 = destFilenames[0];
+        var last$$1 = destFilenames[0];
+        var _iteratorNormalCompletion = true;
+        var _didIteratorError = false;
+        var _iteratorError = undefined;
+
+        try {
+            for (var _iterator = destFilenames[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                var destFilename = _step.value;
+
+                if (destFilename < first$$1) {
+                    first$$1 = destFilename;
+                }
+                if (destFilename > last$$1) {
+                    last$$1 = destFilename;
+                }
+            }
+        } catch (err) {
+            _didIteratorError = true;
+            _iteratorError = err;
+        } finally {
+            try {
+                if (!_iteratorNormalCompletion && _iterator.return) {
+                    _iterator.return();
+                }
+            } finally {
+                if (_didIteratorError) {
+                    throw _iteratorError;
+                }
+            }
+        }
+
+        if (first$$1 == last$$1) {
+            // 1 or more of the same file.
+            if (destFilenames.length == 1) {
+                return destFilenames[0];
+            } else {
+                return destFilenames[0] + "x" + destFilenames.length;
+            }
+        }
+        var commonPrefixLength = 0;
+        while (first$$1[commonPrefixLength] == last$$1[commonPrefixLength] && commonPrefixLength <= first$$1.length) {
+            commonPrefixLength++;
+        }
+        if (commonPrefixLength > 2) {
+            // If the common prefix is significant in length, use it.
+            return first$$1.slice(0, commonPrefixLength) + "_Various";
+        }
+        return destFilenames[0]; // Default, return the first file.
     };
 
     self.tempSTLFilename = function () {
@@ -31659,8 +31746,9 @@ function SlicerViewModel(parameters) {
     function startLongRunning(func) {
         $('#tab_plugin_slicer > div.translucent-blocker').show();
         setTimeout(function () {
-            func();
+            var result$$1 = func();
             $('#tab_plugin_slicer > div.translucent-blocker').hide();
+            return result$$1;
         }, 25);
     }
 

--- a/octoprint_slicer/static/js/octoprint_slicer.min.js
+++ b/octoprint_slicer/static/js/octoprint_slicer.min.js
@@ -30581,8 +30581,8 @@ function STLViewPort(canvas, width, height) {
 
     self.duplicateSelectedModel = function (copies) {
         var models = [];
+        var originalModel = self.selectedModel();
         for (var i = 0; i < copies; i++) {
-            var originalModel = self.selectedModel();
             models.push(self.addModelOfGeometry(originalModel.children[0].geometry.clone(), originalModel));
         }
         return models;
@@ -30597,12 +30597,13 @@ function STLViewPort(canvas, width, height) {
         var geometry = originalModel.children[0].geometry;
         var newGeometries = BufferGeometryAnalyzer.isolatedGeometries(geometry);
 
-        return map$1(newGeometries, function (geometry) {
+        var newModels = map$1(newGeometries, function (geometry) {
             return self.addModelOfGeometry(geometry, originalModel);
         });
 
         self.removeModel(originalModel);
         self.dispatchEvent({ type: eventType.delete, models: [originalModel] });
+        return newModels;
     };
 
     self.onlyOneOriginalModel = function () {
@@ -31229,7 +31230,6 @@ function SlicerViewModel(parameters) {
         if (self.stlViewPort.models().length == 0) {
             self.resetToDefault();
         }
-        self.setDestinationFilename();
         updateValueInputs();
         updateControlState();
         new ModelArranger().arrange(self.stlViewPort.models());
@@ -31350,6 +31350,7 @@ function SlicerViewModel(parameters) {
 
         $("#slicer-viewport button.remove").click(function (event) {
             self.stlViewPort.removeSelectedModel();
+            self.setDestinationFilename();
         });
 
         $("#slicer-viewport button.more").click(function (event) {
@@ -31359,32 +31360,58 @@ function SlicerViewModel(parameters) {
         $("#slicer-viewport button#clear").click(function (event) {
             self.stlViewPort.removeAllModels();
             self.resetToDefault();
+            self.setDestinationFilename();
         });
 
         $("#slicer-viewport button#split").click(function (event) {
             var originalFilename = self.stlViewPort.selectedModel().userData.filename;
-            var models = startLongRunning(self.stlViewPort.splitSelectedModel);
-            var partNumber = 1;
-            forEach$1(models, function (model) {
-                if (models.length < 2) {
-                    model.userData.filename = originalFilename;
-                } else {
-                    model.userData.filename = originalFilename.substr(0, originalFilename.lastIndexOf(".")) + "_split" + partNumber + originalFilename.substr(originalFilename.lastIndexOf(".") + 1);
+            startLongRunning(self.stlViewPort.splitSelectedModel, function (models) {
+                var partNumber = 1;
+                var _iteratorNormalCompletion = true;
+                var _didIteratorError = false;
+                var _iteratorError = undefined;
+
+                try {
+                    for (var _iterator = models[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                        var model = _step.value;
+
+                        if (models.length < 2) {
+                            model.userData.filename = originalFilename;
+                        } else {
+                            model.userData.filename = originalFilename.substr(0, originalFilename.lastIndexOf(".")) + "_split" + partNumber + originalFilename.substr(originalFilename.lastIndexOf("."));
+                            partNumber++;
+                        }
+                    }
+                } catch (err) {
+                    _didIteratorError = true;
+                    _iteratorError = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion && _iterator.return) {
+                            _iterator.return();
+                        }
+                    } finally {
+                        if (_didIteratorError) {
+                            throw _iteratorError;
+                        }
+                    }
                 }
+
+                self.setDestinationFilename();
             });
-            self.setDestinationFilename();
         });
 
         $("#slicer-viewport button#duplicate").click(function (event) {
             var copies = parseInt(prompt("The number of copies you want to duplicate:", 1));
             if (copies != NaN) {
-                var originalFilename = self.stlViewPoint.selectedModel().userData.filename;
-                var models = startLongRunning(self.stlViewPort.duplicateSelectedModel.bind(self, copies));
-                forEach$1(models, function (model) {
-                    model.userData.filename = originalFilename;
+                var originalFilename = self.stlViewPort.selectedModel().userData.filename;
+                startLongRunning(self.stlViewPort.duplicateSelectedModel.bind(self, copies), function (models) {
+                    forEach$1(models, function (model) {
+                        model.userData.filename = originalFilename;
+                    });
+                    self.setDestinationFilename();
                 });
             }
-            self.setDestinationFilename();
         });
 
         $("#slicer-viewport button#lay-flat").click(function (event) {
@@ -31683,13 +31710,13 @@ function SlicerViewModel(parameters) {
         // Find the common prefix.
         var first$$1 = destFilenames[0];
         var last$$1 = destFilenames[0];
-        var _iteratorNormalCompletion = true;
-        var _didIteratorError = false;
-        var _iteratorError = undefined;
+        var _iteratorNormalCompletion2 = true;
+        var _didIteratorError2 = false;
+        var _iteratorError2 = undefined;
 
         try {
-            for (var _iterator = destFilenames[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-                var destFilename = _step.value;
+            for (var _iterator2 = destFilenames[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                var destFilename = _step2.value;
 
                 if (destFilename < first$$1) {
                     first$$1 = destFilename;
@@ -31699,16 +31726,16 @@ function SlicerViewModel(parameters) {
                 }
             }
         } catch (err) {
-            _didIteratorError = true;
-            _iteratorError = err;
+            _didIteratorError2 = true;
+            _iteratorError2 = err;
         } finally {
             try {
-                if (!_iteratorNormalCompletion && _iterator.return) {
-                    _iterator.return();
+                if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                    _iterator2.return();
                 }
             } finally {
-                if (_didIteratorError) {
-                    throw _iteratorError;
+                if (_didIteratorError2) {
+                    throw _iteratorError2;
                 }
             }
         }
@@ -31743,12 +31770,12 @@ function SlicerViewModel(parameters) {
     // internal functions
     ///////////////////////
 
-    function startLongRunning(func) {
+    function startLongRunning(func, callback) {
         $('#tab_plugin_slicer > div.translucent-blocker').show();
         setTimeout(function () {
             var result$$1 = func();
             $('#tab_plugin_slicer > div.translucent-blocker').hide();
-            return result$$1;
+            callback(result$$1);
         }, 25);
     }
 

--- a/src/STLViewPort.js
+++ b/src/STLViewPort.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-import { forEach } from 'lodash-es';
+import { forEach, map } from 'lodash-es';
 import * as THREE from 'three';
 import { BufferGeometryAnalyzer, OrbitControls, TransformControls, STLLoader, PointerInteractions } from '3tk';
 import { OrientationOptimizer } from './OrientationOptimizer';
@@ -160,7 +160,7 @@ export function STLViewPort( canvas, width, height ) {
 
     self.loadSTL = function ( url, onLoad ) {
         new STLLoader().load(url, function ( geometry ) {
-            self.addModelOfGeometry(geometry);
+            onLoad(self.addModelOfGeometry(geometry));
         });
     };
 
@@ -335,10 +335,12 @@ export function STLViewPort( canvas, width, height ) {
     };
 
     self.duplicateSelectedModel = function( copies ) {
+        var models = [];
+        var originalModel = self.selectedModel();
         for (var i = 0; i < copies; i++) {
-            var originalModel = self.selectedModel();
-            self.addModelOfGeometry( originalModel.children[0].geometry.clone(), originalModel);
+            models.push(self.addModelOfGeometry( originalModel.children[0].geometry.clone(), originalModel));
         }
+        return models;
     };
 
     self.splitSelectedModel = function() {
@@ -350,8 +352,8 @@ export function STLViewPort( canvas, width, height ) {
         var geometry = originalModel.children[0].geometry;
         var newGeometries = BufferGeometryAnalyzer.isolatedGeometries(geometry);
 
-        forEach(newGeometries, function(geometry) {
-            self.addModelOfGeometry( geometry, originalModel );
+        return map(newGeometries, function(geometry) {
+            return self.addModelOfGeometry( geometry, originalModel );
         });
 
         self.removeModel( originalModel );

--- a/src/STLViewPort.js
+++ b/src/STLViewPort.js
@@ -352,12 +352,13 @@ export function STLViewPort( canvas, width, height ) {
         var geometry = originalModel.children[0].geometry;
         var newGeometries = BufferGeometryAnalyzer.isolatedGeometries(geometry);
 
-        return map(newGeometries, function(geometry) {
+        var newModels =  map(newGeometries, function(geometry) {
             return self.addModelOfGeometry( geometry, originalModel );
         });
 
         self.removeModel( originalModel );
         self.dispatchEvent( { type: eventType.delete, models: [originalModel] } );
+        return newModels;
     };
 
     self.onlyOneOriginalModel = function() {

--- a/src/slicer.js
+++ b/src/slicer.js
@@ -274,15 +274,15 @@ function SlicerViewModel(parameters) {
         $("#slicer-viewport button#split").click(function(event) {
             var originalFilename = self.stlViewPort.selectedModel().userData.filename;
             startLongRunning( self.stlViewPort.splitSelectedModel, function (models) {
-                var partNumber = 1;
-                for (var model of models) {
-                    if (models.length < 2) {
-                        model.userData.filename = originalFilename;
-                    } else {
+                if (models.length == 1) {
+                    models[0].userData.filename = originalFilename;
+                } else {
+                    var partNumber = 1;
+                    for (var model of models) {
                         model.userData.filename =
                             originalFilename.substr(0, originalFilename.lastIndexOf(".")) +
                             "_split" + partNumber +
-                        originalFilename.substr(originalFilename.lastIndexOf("."));
+                            originalFilename.substr(originalFilename.lastIndexOf("."));
                         partNumber++;
                     }
                 }
@@ -568,12 +568,15 @@ function SlicerViewModel(parameters) {
 
     // END: Helpers for drawing walls and floor
 
-    let filenames = [];
     self.resetSlicingViewModel = function() {
         self.slicingViewModel.target = undefined;
         self.slicingViewModel.file(undefined);
         self.slicingViewModel.destinationFilename(undefined);
-        filenames = [];
+    };
+
+    self.setSlicingViewModel = function(target, filename) {
+        self.slicingViewModel.target = target;
+        self.slicingViewModel.file(filename);
     };
 
     let previousDestinationFilename = "";
@@ -588,11 +591,6 @@ function SlicerViewModel(parameters) {
             self.slicingViewModel.destinationFilename(previousDestinationFilename);
         }
     }
-
-    self.setSlicingViewModel = function(target, filename) {
-        self.slicingViewModel.target = target;
-        self.slicingViewModel.file(filename);
-    };
 
     // Returns the destination filename based on which models are loaded.
     // The destination filename is without the final .gco on it because

--- a/src/slicer.js
+++ b/src/slicer.js
@@ -281,7 +281,7 @@ function SlicerViewModel(parameters) {
                     for (var model of models) {
                         model.userData.filename =
                             originalFilename.substr(0, originalFilename.lastIndexOf(".")) +
-                            "_split" + partNumber +
+                            "_Split" + partNumber +
                             originalFilename.substr(originalFilename.lastIndexOf("."));
                         partNumber++;
                     }
@@ -622,8 +622,10 @@ function SlicerViewModel(parameters) {
         if (first == last) {
             // 1 or more of the same file.
             if (destFilenames.length == 1) {
+                // Just one file.
                 return destFilenames[0];
             } else {
+                // More than 1 of the same file.
                 return destFilenames[0] + "x" + destFilenames.length;
             }
         }

--- a/src/slicer.js
+++ b/src/slicer.js
@@ -14,7 +14,7 @@ import { STLViewPort } from './STLViewPort';
 import { OverridesViewModel } from './profile_overrides';
 import { ModelArranger } from './ModelArranger';
 import { CheckerboardMaterial } from './CheckerboardMaterial';
-import { find, forEach, endsWith, some, extend } from 'lodash-es';
+import { find, forEach, endsWith, some, extend, map } from 'lodash-es';
 
 function isDev() {
     return window.location.hostname == "localhost";
@@ -106,7 +106,10 @@ function SlicerViewModel(parameters) {
     self.addSTL = function(target, file) {
         self.newSession = false;
         $('#tab_plugin_slicer > div.translucent-blocker').show();
-        self.stlViewPort.loadSTL(BASEURL + "downloads/files/" + target + "/" + file);
+        self.stlViewPort.loadSTL(BASEURL + "downloads/files/" + target + "/" + file, function (model) {
+            model.userData.filename = file;
+            self.setDestinationFilename();
+        });
     }
 
     self.onModelAdd = function(event) {
@@ -128,6 +131,7 @@ function SlicerViewModel(parameters) {
         if (self.stlViewPort.models().length == 0) {
             self.resetToDefault();
         }
+        self.setDestinationFilename();
         updateValueInputs();
         updateControlState();
         new ModelArranger().arrange(self.stlViewPort.models());
@@ -267,14 +271,32 @@ function SlicerViewModel(parameters) {
         });
 
         $("#slicer-viewport button#split").click(function(event) {
-            startLongRunning( self.stlViewPort.splitSelectedModel );
+            var originalFilename = self.stlViewPort.selectedModel().userData.filename;
+            var models = startLongRunning( self.stlViewPort.splitSelectedModel );
+            var partNumber = 1;
+            forEach(models, function (model) {
+                if (models.length < 2) {
+                    model.userData.filename = originalFilename;
+                } else {
+                    model.userData.filename =
+                        originalFilename.substr(0, originalFilename.lastIndexOf(".")) +
+                        "_split" + partNumber++ +
+                        originalFilename.substr(originalFilename.lastIndexOf(".") + 1);
+                }
+            });
+            self.setDestinationFilename();
         });
 
         $("#slicer-viewport button#duplicate").click(function(event) {
             var copies = parseInt( prompt("The number of copies you want to duplicate:", 1) );
             if (copies != NaN) {
-                startLongRunning( self.stlViewPort.duplicateSelectedModel.bind(self, copies) );
+                let originalFilename = self.stlViewPoint.selectedModel().userData.filename;
+                var models = startLongRunning( self.stlViewPort.duplicateSelectedModel.bind(self, copies) );
+                forEach(models, function (model) {
+                    model.userData.filename = originalFilename;
+                });
             }
+            self.setDestinationFilename();
         });
 
         $("#slicer-viewport button#lay-flat").click(function(event) {
@@ -550,27 +572,68 @@ function SlicerViewModel(parameters) {
         filenames = [];
     };
 
-    self.setSlicingViewModel = function(target, filename) {
+    let previousDestinationFilename = "";
+    self.setDestinationFilename = function() {
         if (!self.slicingViewModel.destinationFilename() ||
-            self.slicingViewModel.destinationFilename() != self.computeDestinationFilename(filenames)) {
-            // No current name or the previous name was unchanged.
-            filesnames.push(filename);
-            self.slicingViewModel.target = target;
-            self.slicingViewModel.file(filename);
-            self.slicingViewModel.destinationFilename(self.computeDestinationFilename(filenames));
+            self.slicingViewModel.destinationFilename() == previousDestinationFilename) {
+            // No previous destination filename or it was unchanged.
+            let filenames = map(self.stlViewPort.models(), function (model) {
+                return model.userData.filename;
+            });
+            previousDestinationFilename = self.computeDestinationFilename(filenames);
+            self.slicingViewModel.destinationFilename(previousDestinationFilename);
         }
+    }
+
+    self.setSlicingViewModel = function(target, filename) {
+        self.slicingViewModel.target = target;
+        self.slicingViewModel.file(filename);
     };
 
     // Returns the destination filename based on which models are loaded.
     // The destination filename is without the final .gco on it because
     // that will depend on the slicer.
-    self.computeDestinationFilename = function(inputFilename) {
-        // TODO: For now, just use the first model's name.
-        var destinationFilename = inputFilename.substr(0, inputFilename.lastIndexOf("."));
-        if (destinationFilename.lastIndexOf("/") != 0) {
-            destinationFilename = destinationFilename.substr(destinationFilename.lastIndexOf("/") + 1);
+    self.computeDestinationFilename = function(inputFilenames) {
+        if (inputFilenames.length == 0) {
+            return "";
         }
-        return destinationFilename;
+        // First, sanitize the filenames to extract the file name.
+        var destFilenames = map(inputFilenames, function(inputFilename) {
+            let destFilename = inputFilename.substr(0, inputFilename.lastIndexOf("."));
+            if (destFilename.lastIndexOf("/") != 0) {
+                destFilename = destFilename.substr(destFilename.lastIndexOf("/") + 1);
+            }
+            return destFilename;
+        });
+
+        // Find the common prefix.
+        let first = destFilenames[0];
+        let last = destFilenames[0];
+        for (let destFilename of destFilenames) {
+            if (destFilename < first) {
+                first = destFilename;
+            }
+            if (destFilename > last) {
+                last = destFilename;
+            }
+        }
+        if (first == last) {
+            // 1 or more of the same file.
+            if (destFilenames.length == 1) {
+                return destFilenames[0];
+            } else {
+                return destFilenames[0] + "x" + destFilenames.length;
+            }
+        }
+        let commonPrefixLength = 0;
+        while (first[commonPrefixLength] == last[commonPrefixLength] && commonPrefixLength <= first.length) {
+            commonPrefixLength++;
+        }
+        if (commonPrefixLength > 2) {
+            // If the common prefix is significant in length, use it.
+            return first.slice(0, commonPrefixLength) + "_Various";
+        }
+        return destFilenames[0];  // Default, return the first file.
     };
 
     self.tempSTLFilename = function() {
@@ -589,8 +652,9 @@ function SlicerViewModel(parameters) {
     function startLongRunning( func ) {
         $('#tab_plugin_slicer > div.translucent-blocker').show();
         setTimeout( function() {
-            func();
+            let result = func();
             $('#tab_plugin_slicer > div.translucent-blocker').hide();
+            return result;
         }, 25);
     }
 

--- a/src/slicer.js
+++ b/src/slicer.js
@@ -542,17 +542,22 @@ function SlicerViewModel(parameters) {
 
     // END: Helpers for drawing walls and floor
 
+    let filenames = [];
     self.resetSlicingViewModel = function() {
         self.slicingViewModel.target = undefined;
         self.slicingViewModel.file(undefined);
         self.slicingViewModel.destinationFilename(undefined);
+        filenames = [];
     };
 
     self.setSlicingViewModel = function(target, filename) {
-        if (!self.slicingViewModel.destinationFilename()) {  // A model is added to an empty bed
+        if (!self.slicingViewModel.destinationFilename() ||
+            self.slicingViewModel.destinationFilename() != self.computeDestinationFilename(filenames)) {
+            // No current name or the previous name was unchanged.
+            filesnames.push(filename);
             self.slicingViewModel.target = target;
             self.slicingViewModel.file(filename);
-            self.slicingViewModel.destinationFilename(self.computeDestinationFilename(filename));
+            self.slicingViewModel.destinationFilename(self.computeDestinationFilename(filenames));
         }
     };
 


### PR DESCRIPTION
Try to compute a smarter destination filename.

Currently it just uses the first model added to the platform.  With this fix, look at the name of all the models on the platform and come up with a better name:

* If all the models are the same, for example, 5 of the same model, add "x5" to the end.
* If all the models have the same prefix, set the filename to "THE_PREFIX_Various".
* If a model is split, number them with "_Split1", "_Split2", etc, and use the same rules as above.
* If no better name can be described, fallback to the original naming system (the first model)