### PR TITLE
Printer profile updates

### DIFF
--- a/octoprint_slicer/static/js/octoprint_slicer.min.js
+++ b/octoprint_slicer/static/js/octoprint_slicer.min.js
@@ -32565,12 +32565,15 @@ function SlicerViewModel(parameters) {
         new ModelArranger().arrange(self.stlViewPort.models());
     };
 
-    self.updatePrinterBed = function (profileName) {
-        if (profileName) {
-            var profile = find$1(self.printerProfilesViewModel.profiles.items(), function (p) {
-                return p.id == profileName;
-            });
-
+    ko.computed(function () {
+        var profileName = self.slicingViewModel.printerProfile();
+        if (!profileName) {
+            return;
+        }
+        var profile = find$1(self.printerProfilesViewModel.profiles.items(), function (p) {
+            return p.id == profileName;
+        });
+        if (profile) {
             var dim = profile.volume;
             self.BEDSIZE_X_MM = Math.max(dim.width, 0.1); // Safari will error if rectShape has dimensions being 0
             self.BEDSIZE_Y_MM = Math.max(dim.depth, 0.1);
@@ -32583,12 +32586,10 @@ function SlicerViewModel(parameters) {
                 self.ORIGIN_OFFSET_X_MM = 0;
                 self.ORIGIN_OFFSET_Y_MM = 0;
             }
+            self.drawBedFloor(self.BEDSIZE_X_MM, self.BEDSIZE_Y_MM, self.BED_FORM_FACTOR);
+            self.drawWalls(self.BEDSIZE_X_MM, self.BEDSIZE_Y_MM, self.BEDSIZE_Z_MM, self.BED_FORM_FACTOR);
         }
-        self.drawBedFloor(self.BEDSIZE_X_MM, self.BEDSIZE_Y_MM, self.BED_FORM_FACTOR);
-        self.drawWalls(self.BEDSIZE_X_MM, self.BEDSIZE_Y_MM, self.BEDSIZE_Z_MM, self.BED_FORM_FACTOR);
-    };
-
-    self.slicingViewModel.printerProfile.subscribe(self.updatePrinterBed);
+    });
 
     self.BEDSIZE_X_MM = 200;
     self.BEDSIZE_Y_MM = 200;
@@ -32618,8 +32619,6 @@ function SlicerViewModel(parameters) {
         self.floor = new Object3D();
         self.stlViewPort.scene.add(self.walls);
         self.stlViewPort.scene.add(self.floor);
-
-        self.updatePrinterBed();
 
         ko.applyBindings(self.slicingViewModel, $('#slicing-settings')[0]);
 
@@ -32936,9 +32935,9 @@ function SlicerViewModel(parameters) {
 
         if (formFactor == "circular") {
 
-            var cylGeometry = new CylinderGeometry(width / 2, width / 2, self.BEDSIZE_Z_MM, 60, 1, true);
+            var cylGeometry = new CylinderGeometry(width / 2, width / 2, height, 60, 1, true);
             // Move the walls up to the floor
-            cylGeometry.applyMatrix(new Matrix4().makeTranslation(0, self.BEDSIZE_Z_MM / 2, 0));
+            cylGeometry.applyMatrix(new Matrix4().makeTranslation(0, height / 2, 0));
             var wall = new Mesh(cylGeometry, wallMaterial);
             //rotate the walls so they are upright
             wall.rotation.x = Math.PI / 2;

--- a/octoprint_slicer/static/js/octoprint_slicer.min.js
+++ b/octoprint_slicer/static/js/octoprint_slicer.min.js
@@ -32567,13 +32567,11 @@ function SlicerViewModel(parameters) {
 
     ko.computed(function () {
         var profileName = self.slicingViewModel.printerProfile();
-        if (!profileName) {
-            return;
-        }
-        var profile = find$1(self.printerProfilesViewModel.profiles.items(), function (p) {
-            return p.id == profileName;
-        });
-        if (profile) {
+        if (profileName) {
+            var profile = find$1(self.printerProfilesViewModel.profiles.items(), function (p) {
+                return p.id == profileName;
+            });
+
             var dim = profile.volume;
             self.BEDSIZE_X_MM = Math.max(dim.width, 0.1); // Safari will error if rectShape has dimensions being 0
             self.BEDSIZE_Y_MM = Math.max(dim.depth, 0.1);

--- a/src/slicer.js
+++ b/src/slicer.js
@@ -135,12 +135,10 @@ function SlicerViewModel(parameters) {
 
     ko.computed(function() {
         var profileName = self.slicingViewModel.printerProfile();
-        if (!profileName) {
-            return;
-        }
-        var profile = find(self.printerProfilesViewModel.profiles.items(),
-                           function(p) { return p.id == profileName });
-        if (profile) {
+        if (profileName) {
+            var profile = find(self.printerProfilesViewModel.profiles.items(), function(p) {
+                return p.id == profileName });
+
             var dim = profile.volume;
             self.BEDSIZE_X_MM = Math.max(dim.width, 0.1); // Safari will error if rectShape has dimensions being 0
             self.BEDSIZE_Y_MM = Math.max(dim.depth, 0.1);

--- a/src/slicer.js
+++ b/src/slicer.js
@@ -133,10 +133,14 @@ function SlicerViewModel(parameters) {
         new ModelArranger().arrange(self.stlViewPort.models());
     };
 
-    self.updatePrinterBed = function(profileName) {
-        if ( profileName) {
-            var profile = find(self.printerProfilesViewModel.profiles.items(), function(p) { return p.id == profileName });
-
+    ko.computed(function() {
+        var profileName = self.slicingViewModel.printerProfile();
+        if (!profileName) {
+            return;
+        }
+        var profile = find(self.printerProfilesViewModel.profiles.items(),
+                           function(p) { return p.id == profileName });
+        if (profile) {
             var dim = profile.volume;
             self.BEDSIZE_X_MM = Math.max(dim.width, 0.1); // Safari will error if rectShape has dimensions being 0
             self.BEDSIZE_Y_MM = Math.max(dim.depth, 0.1);
@@ -149,12 +153,10 @@ function SlicerViewModel(parameters) {
                 self.ORIGIN_OFFSET_X_MM = 0;
                 self.ORIGIN_OFFSET_Y_MM = 0;
             }
+            self.drawBedFloor(self.BEDSIZE_X_MM, self.BEDSIZE_Y_MM, self.BED_FORM_FACTOR);
+            self.drawWalls(self.BEDSIZE_X_MM, self.BEDSIZE_Y_MM, self.BEDSIZE_Z_MM, self.BED_FORM_FACTOR);
         }
-        self.drawBedFloor(self.BEDSIZE_X_MM, self.BEDSIZE_Y_MM, self.BED_FORM_FACTOR);
-        self.drawWalls(self.BEDSIZE_X_MM, self.BEDSIZE_Y_MM, self.BEDSIZE_Z_MM, self.BED_FORM_FACTOR);
-    }
-
-    self.slicingViewModel.printerProfile.subscribe( self.updatePrinterBed );
+    });
 
     self.BEDSIZE_X_MM = 200;
     self.BEDSIZE_Y_MM = 200;
@@ -185,8 +187,6 @@ function SlicerViewModel(parameters) {
         self.floor = new THREE.Object3D();
         self.stlViewPort.scene.add(self.walls);
         self.stlViewPort.scene.add(self.floor);
-
-        self.updatePrinterBed();
 
         ko.applyBindings(self.slicingViewModel, $('#slicing-settings')[0]);
 
@@ -515,9 +515,9 @@ function SlicerViewModel(parameters) {
 
         if (formFactor == "circular") {
 
-            var cylGeometry = new THREE.CylinderGeometry(width/2, width/2, self.BEDSIZE_Z_MM, 60, 1, true);
+            var cylGeometry = new THREE.CylinderGeometry(width/2, width/2, height, 60, 1, true);
             // Move the walls up to the floor
-            cylGeometry.applyMatrix(new THREE.Matrix4().makeTranslation(0, self.BEDSIZE_Z_MM / 2, 0));
+            cylGeometry.applyMatrix(new THREE.Matrix4().makeTranslation(0, height / 2, 0));
             var wall = new THREE.Mesh(cylGeometry, wallMaterial);
             //rotate the walls so they are upright
             wall.rotation.x = Math.PI / 2;


### PR DESCRIPTION
Currently, the walls and floor are not redrawn the printer profile is changed.

This fixes https://github.com/eyal0/OctoPrint-Slicer/issues/10 .

To test, add a model to the platform and then go into settings and change the size of the bed or shape.  Before this PR, there is no effect.  After this PR, the GUI is updated correctly.