### PR TITLE
Fix bug in deleting undefined settings in profile_overrides

### DIFF
--- a/src/profile_overrides.js
+++ b/src/profile_overrides.js
@@ -208,9 +208,9 @@ export function OverridesViewModel(parameters, array_keys, enum_keys, item_keys,
             }
         }
 
-        _.forEach(result, function(k) {
+        _.forEach(result, function(v, k) {
             // If the value is undefined, must not be valid for this slicer.
-            if (result[k] === undefined) {
+            if (k.startsWith("profile.") && result[k] === undefined) {
                 delete result[k];
             }
         });


### PR DESCRIPTION
There is a bug in profile_overrides.js.  It's supposed to delete undefined settings but it doesn't work because _.forEach was used incorrectly.  I checked the new version in the debugger and it should work now.  The bug didn't have any bad side-effects so this isn't too important.