### PR TITLE
Labels for settings

### DIFF
--- a/octoprint_slicer/templates/slicer_tab.jinja2
+++ b/octoprint_slicer/templates/slicer_tab.jinja2
@@ -125,13 +125,8 @@ mixpanel.init("ade6b64c4db77172707571c1f9cfcebe");</script><!-- end Mixpanel -->
                       {{ slicer_select("support", "Support for overhangs", "Support") }}
                       {{ slicer_checkbox("support_material", "Generate support material", "Supports") }}
                       {{ slicer_checkbox("overhangs", "Detect Bridging Perimeters (recommended when using supports)", "Detect overhangs") }}
+                      {{ slicer_checkbox("spiral_vase", "Spiral Vase (automatically adjusts fill, perimeters, top layers, etc)", "Spiral vase") }}
                   </div>
-                      <div title="Spiral Vase (automatically adjusts fill, perimeters, top layers, etc)" class="input-append" data-bind="visible: !_.isUndefined($data['profile.spiral_vase']())">
-                          <label class="control-label">Spiral vase</label>
-                          <div class="controls checkbox">
-                              <input type="checkbox" data-bind="checked: $data['profile.spiral_vase']"></input>
-                          </div>
-                      </div>
               </div>
           </form>
       </div>

--- a/octoprint_slicer/templates/slicer_tab.jinja2
+++ b/octoprint_slicer/templates/slicer_tab.jinja2
@@ -29,28 +29,28 @@ mixpanel.init("ade6b64c4db77172707571c1f9cfcebe");</script><!-- end Mixpanel -->
 </div>
 {%- macro slicer_setting(setting, title, label, callback) -%}
   <div title="{{ title }}" class="input-append" data-bind="visible: !_.isUndefined($data['profile.{{ setting }}']())">
-    <label class="control-label">{{ label }}</label>
+    <label for="slicer_input_{{ setting }}" class="control-label">{{ label }}</label>
     {{ caller() }}
   </div>
 {%- endmacro %}
 {%- macro slicer_checkbox(setting, title, label) -%}
   {% call slicer_setting(setting, title, label) -%}
     <div class="controls checkbox">
-      <input type="checkbox" data-bind="checked: $data['profile.{{ setting }}']"></input>
+      <input id="slicer_input_{{ setting }}" type="checkbox" data-bind="checked: $data['profile.{{ setting }}']"></input>
     </div>
   {%- endcall %}
 {%- endmacro %}
 {%- macro slicer_select(setting, title, label) -%}
   {% call slicer_setting(setting, title, label) -%}
     <div class="controls">
-      <select data-bind="options: $data.optionsForKey('{{ setting }}'), value: $data['profile.{{ setting }}'], valueAllowUnset: true"></select>
+      <select id="slicer_input_{{ setting }}" data-bind="options: $data.optionsForKey('{{ setting }}'), value: $data['profile.{{ setting }}'], valueAllowUnset: true"></select>
     </div>
   {%- endcall %}
 {%- endmacro %}
 {%- macro slicer_number(setting, title, label, min, max, step, add_on) -%}
   {% call slicer_setting(setting, title, label) -%}
     <div class="controls">
-      <input data-bind="numericValue: $data['profile.{{ setting }}']" type="number"
+      <input id="slicer_input_{{ setting }}" data-bind="numericValue: $data['profile.{{ setting }}']" type="number"
              {%- if min is defined %} min="{{ min }}"{% endif -%}
              {%- if max is defined %} max="{{ max }}"{% endif -%}
              {%- if step is defined %} step="{{ step }}">{% endif -%}</input>
@@ -67,36 +67,36 @@ mixpanel.init("ade6b64c4db77172707571c1f9cfcebe");</script><!-- end Mixpanel -->
             <div class="row">
                 <div class="span3">
                     <div class="control-group">
-                        <label class="control-label">{{ _('Slicer') }}</label>
+                        <label for="slicer_Slicer" class="control-label">{{ _('Slicer') }}</label>
                         <div class="controls">
-                            <select data-bind="options: matchingSlicers, optionsText: 'name', optionsValue: 'key', value: slicer"></select>
+                            <select id="slicer_Slicer" data-bind="options: matchingSlicers, optionsText: 'name', optionsValue: 'key', value: slicer"></select>
                         </div>
                     </div>
                     <div class="control-group">
-                        <label class="control-label">{{ _('Printer Profile') }}</label>
+                        <label for="slicer_Printer_Profile" class="control-label">{{ _('Printer Profile') }}</label>
                         <div class="controls">
-                            <select data-bind="options: printerProfiles.profiles.items, optionsText: 'name', optionsValue: 'id', value: printerProfile"></select>
+                            <select id="slicer_Printer_Profile" data-bind="options: printerProfiles.profiles.items, optionsText: 'name', optionsValue: 'id', value: printerProfile"></select>
                         </div>
                     </div>
                     <div class="control-group">
-                        <label class="control-label">{{ _('After slicing...') }}</label>
+                        <label for="slicer_After_slicing" class="control-label">{{ _('After slicing...') }}</label>
                         <div class="controls">
-                            <select data-bind="options: afterSlicingOptions, optionsText: 'text', optionsValue: 'value', value: afterSlicing"></select>
+                            <select id="slicer_After_slicing" data-bind="options: afterSlicingOptions, optionsText: 'text', optionsValue: 'value', value: afterSlicing"></select>
                         </div>
                     </div>
                 </div>
                 <div class="span3">
                     <div class="control-group">
-                        <label class="control-label">{{ _('Slicing Profile') }}</label>
+                        <label for="slicer_Slicing_Profile" class="control-label">{{ _('Slicing Profile') }}</label>
                         <div class="controls">
-                            <select data-bind="options: profiles, optionsText: 'name', optionsValue: 'key', value: profile"></select>
+                            <select id="slicer_Slicing_Profile" data-bind="options: profiles, optionsText: 'name', optionsValue: 'key', value: profile"></select>
                         </div>
                     </div>
                     <div class="control-group">
-                        <label class="control-label">{{ _('Output Filename') }}</label>
+                        <label for="slicer_Output_Filename" class="control-label">{{ _('Output Filename') }}</label>
                         <div class="controls">
                             <div class="input-append">
-                                <input type="text" data-bind="value: destinationFilename"></input>
+                                <input id="slicer_Output_Filename" type="text" data-bind="value: destinationFilename"></input>
                                 <span class="add-on" data-bind="text: '.' + destinationExtension()"></span>
                             </div>
                         </div>
@@ -174,9 +174,9 @@ mixpanel.init("ade6b64c4db77172707571c1f9cfcebe");</script><!-- end Mixpanel -->
       <div class="row">
           <div class="span7">
               <div title="GCode inserted at the beginning" class="input-append">
-                  <label>Start GCode:</label>
+                  <label for="slicer_Start_GCode">Start GCode:</label>
                   <div class="controls">
-                      <textarea data-bind="value: $data['profile.start_gcode']"></textarea>
+                      <textarea id="slicer_Start_GCode" data-bind="value: $data['profile.start_gcode']"></textarea>
                   </div>
               </div>
           </div>
@@ -184,9 +184,9 @@ mixpanel.init("ade6b64c4db77172707571c1f9cfcebe");</script><!-- end Mixpanel -->
       <div class="row">
           <div class="span7">
               <div title="GCode inserted at the end" class="input-append">
-                  <label>End GCode:</label>
+                  <label for="slicer_End_GCode">End GCode:</label>
                   <div class="controls">
-                      <textarea data-bind="value: $data['profile.end_gcode']"></textarea>
+                      <textarea id="slicer_End_GCode" data-bind="value: $data['profile.end_gcode']"></textarea>
                   </div>
               </div>
           </div>


### PR DESCRIPTION
Add a "for" on each label and an "id" on each input.  This makes the labels clickable, especially useful for checkboxes.

In testing, I clicked on a few of the settings and they seemed to work.

This is based on [this PR](https://github.com/kennethjiang/OctoPrint-Slicer/pull/149), don't merge this until the other is merged first.