### PR TITLE
Pause WebGL rendering when slicer tab not active

### DIFF
--- a/src/STLViewPort.js
+++ b/src/STLViewPort.js
@@ -33,6 +33,7 @@ export function STLViewPort( canvas, width, height ) {
     self.canvas = canvas;
     self.canvasWidth = width;
     self.canvasHeight = height;
+    self.renderingPaused = true;
 
     self.effectController = {
         metalness: 0.5,
@@ -132,15 +133,25 @@ export function STLViewPort( canvas, width, height ) {
 
     }
 
+    self.pauseRendering = function() {
+        self.renderingPaused = true;
+    }
+
+    self.unpauseRendering = function() {
+        self.renderingPaused = false;
+    }
+
     self.animate = function() {
         requestAnimationFrame( self.animate );
 
-        self.update();
-        self.transformControls.update();
-        self.orbitControls.update();
-        if (self.stats) self.stats.update();
+        if (!self.renderingPaused) {
+            self.update();
+            self.transformControls.update();
+            self.orbitControls.update();
+            if (self.stats) self.stats.update();
 
-        self.render();
+            self.render();
+        }
     };
 
     self.update = function() {

--- a/src/slicer.js
+++ b/src/slicer.js
@@ -574,6 +574,18 @@ function SlicerViewModel(parameters) {
             self.slicingViewModel.file().slice(pos)].join('');
     };
 
+    // Pause WebGL rendering when slicer tab is inactive
+    self.onTabChange = function (next, current) {
+        if (current === "#tab_plugin_slicer") {
+            self.stlViewPort.pauseRendering();
+        }
+    }
+    self.onAfterTabChange = function (current, previous) {
+        if (current === "#tab_plugin_slicer") {
+            self.stlViewPort.unpauseRendering();
+        }
+    }
+
     self.init();
 
     //////////////////////


### PR DESCRIPTION
Pauses WebGL rendering when the Slicer plugin is not the active tab within Octoprint.  Massively reduces any performance overhead when the Slicer plugin isn't visible, which should help performance on lower-end devices.

## Background / the issue
Recently, I've found that my laptop (running Ubuntu 18.04 on an i7 with a discrete Nvidia graphics card - so by no means underpowered) starts to lag badly when I'm viewing the Octoprint UI in Chrome.  I finally got around to investigating the cause, and was surprised to find that it only seems to happen when not only is the Octoprint tab active in Chrome, but the Slicer tab **isn't** active - if I switch to the Slicer tab, the lag goes away.

I managed to grab a performance trace using Chrome dev tools, and found that when the Slicer plugin tab isn't active, calls to `uniformMatrix2fv()` were taking up to 3.5 seconds!  This turned out to be a WebGL function, but following it back up the stack, I found that it ultimately gets called from `STLViewPort`'s `animate()`, which is scheduled via `requestAnimationFrame`.

## The workaround/fix
I haven't got any experience at all with WebGL, so I'm not sure if there's much (if anything) which can be done to resolve the issue directly (as it may be an implementation issue specific to my hardware/software stack) - but I figured that an easy way to work around it would be to simply pause any WebGL rendering while the Slicer plugin tab isn't active.  Since you can't see it, there's no need to render it anyway - so I've implemented a basic pause function which simply skips doing the update / render if it's "paused", and added an `onTabChange` hook to pause rendering _before_ switching away from the Slicer plugin tab, and an `onAfterTabChange` hook to unpause rendering _after_ switching to the Slicer plugin tab.  I opted to leave `animate()` running via `requestAnimationFrame` so that the pause/unpause only needs to toggle a flag, rather than needing a way to break out of the `requestAnimationFrame` cycle and restart it.

I've tested this change in my environment, and the only noticeable change is the absence of any lag when the Slicer plugin tab isn't active.  Performance traces show that very little time is now spent in `animate()` and its call tree when the plugin tab isn't active - so this change might also help improve performance for users on low-end devices, even if they're not currently seeing the massive lag spikes which I've been experiencing.